### PR TITLE
fix to work on python 3

### DIFF
--- a/code/Quickstart.ipynb
+++ b/code/Quickstart.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -8,6 +9,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -27,6 +29,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -34,6 +37,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -53,6 +57,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -70,19 +75,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[34mDE001\u001b[m\u001b[m/         \u001b[34mDE014\u001b[m\u001b[m/         \u001b[34mDE027\u001b[m\u001b[m/         \u001b[34mDE040\u001b[m\u001b[m/         \u001b[34mDE053\u001b[m\u001b[m/         \u001b[34mDE066\u001b[m\u001b[m/         \u001b[34mDE079\u001b[m\u001b[m/         \u001b[34mDE092\u001b[m\u001b[m/\r\n",
-      "\u001b[34mDE002\u001b[m\u001b[m/         \u001b[34mDE015\u001b[m\u001b[m/         \u001b[34mDE028\u001b[m\u001b[m/         \u001b[34mDE041\u001b[m\u001b[m/         \u001b[34mDE054\u001b[m\u001b[m/         \u001b[34mDE067\u001b[m\u001b[m/         \u001b[34mDE080\u001b[m\u001b[m/         \u001b[34mDE093\u001b[m\u001b[m/\r\n",
-      "\u001b[34mDE003\u001b[m\u001b[m/         \u001b[34mDE016\u001b[m\u001b[m/         \u001b[34mDE029\u001b[m\u001b[m/         \u001b[34mDE042\u001b[m\u001b[m/         \u001b[34mDE055\u001b[m\u001b[m/         \u001b[34mDE068\u001b[m\u001b[m/         \u001b[34mDE081\u001b[m\u001b[m/         \u001b[34mDE094\u001b[m\u001b[m/\r\n",
-      "\u001b[34mDE004\u001b[m\u001b[m/         \u001b[34mDE017\u001b[m\u001b[m/         \u001b[34mDE030\u001b[m\u001b[m/         \u001b[34mDE043\u001b[m\u001b[m/         \u001b[34mDE056\u001b[m\u001b[m/         \u001b[34mDE069\u001b[m\u001b[m/         \u001b[34mDE082\u001b[m\u001b[m/         \u001b[34mDE095\u001b[m\u001b[m/\r\n",
-      "\u001b[34mDE005\u001b[m\u001b[m/         \u001b[34mDE018\u001b[m\u001b[m/         \u001b[34mDE031\u001b[m\u001b[m/         \u001b[34mDE044\u001b[m\u001b[m/         \u001b[34mDE057\u001b[m\u001b[m/         \u001b[34mDE070\u001b[m\u001b[m/         \u001b[34mDE083\u001b[m\u001b[m/         \u001b[34mDE096\u001b[m\u001b[m/\r\n",
-      "\u001b[34mDE006\u001b[m\u001b[m/         \u001b[34mDE019\u001b[m\u001b[m/         \u001b[34mDE032\u001b[m\u001b[m/         \u001b[34mDE045\u001b[m\u001b[m/         \u001b[34mDE058\u001b[m\u001b[m/         \u001b[34mDE071\u001b[m\u001b[m/         \u001b[34mDE084\u001b[m\u001b[m/         \u001b[31mcontents.json\u001b[m\u001b[m*\r\n",
-      "\u001b[34mDE007\u001b[m\u001b[m/         \u001b[34mDE020\u001b[m\u001b[m/         \u001b[34mDE033\u001b[m\u001b[m/         \u001b[34mDE046\u001b[m\u001b[m/         \u001b[34mDE059\u001b[m\u001b[m/         \u001b[34mDE072\u001b[m\u001b[m/         \u001b[34mDE085\u001b[m\u001b[m/         \u001b[31mtruth.json\u001b[m\u001b[m*\r\n",
-      "\u001b[34mDE008\u001b[m\u001b[m/         \u001b[34mDE021\u001b[m\u001b[m/         \u001b[34mDE034\u001b[m\u001b[m/         \u001b[34mDE047\u001b[m\u001b[m/         \u001b[34mDE060\u001b[m\u001b[m/         \u001b[34mDE073\u001b[m\u001b[m/         \u001b[34mDE086\u001b[m\u001b[m/         \u001b[31mtruth.txt\u001b[m\u001b[m*\r\n",
-      "\u001b[34mDE009\u001b[m\u001b[m/         \u001b[34mDE022\u001b[m\u001b[m/         \u001b[34mDE035\u001b[m\u001b[m/         \u001b[34mDE048\u001b[m\u001b[m/         \u001b[34mDE061\u001b[m\u001b[m/         \u001b[34mDE074\u001b[m\u001b[m/         \u001b[34mDE087\u001b[m\u001b[m/\r\n",
-      "\u001b[34mDE010\u001b[m\u001b[m/         \u001b[34mDE023\u001b[m\u001b[m/         \u001b[34mDE036\u001b[m\u001b[m/         \u001b[34mDE049\u001b[m\u001b[m/         \u001b[34mDE062\u001b[m\u001b[m/         \u001b[34mDE075\u001b[m\u001b[m/         \u001b[34mDE088\u001b[m\u001b[m/\r\n",
-      "\u001b[34mDE011\u001b[m\u001b[m/         \u001b[34mDE024\u001b[m\u001b[m/         \u001b[34mDE037\u001b[m\u001b[m/         \u001b[34mDE050\u001b[m\u001b[m/         \u001b[34mDE063\u001b[m\u001b[m/         \u001b[34mDE076\u001b[m\u001b[m/         \u001b[34mDE089\u001b[m\u001b[m/\r\n",
-      "\u001b[34mDE012\u001b[m\u001b[m/         \u001b[34mDE025\u001b[m\u001b[m/         \u001b[34mDE038\u001b[m\u001b[m/         \u001b[34mDE051\u001b[m\u001b[m/         \u001b[34mDE064\u001b[m\u001b[m/         \u001b[34mDE077\u001b[m\u001b[m/         \u001b[34mDE090\u001b[m\u001b[m/\r\n",
-      "\u001b[34mDE013\u001b[m\u001b[m/         \u001b[34mDE026\u001b[m\u001b[m/         \u001b[34mDE039\u001b[m\u001b[m/         \u001b[34mDE052\u001b[m\u001b[m/         \u001b[34mDE065\u001b[m\u001b[m/         \u001b[34mDE078\u001b[m\u001b[m/         \u001b[34mDE091\u001b[m\u001b[m/\r\n"
+      "\u001b[1m\u001b[36mDE001\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE021\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE041\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE061\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE081\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE002\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE022\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE042\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE062\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE082\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE003\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE023\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE043\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE063\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE083\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE004\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE024\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE044\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE064\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE084\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE005\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE025\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE045\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE065\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE085\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE006\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE026\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE046\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE066\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE086\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE007\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE027\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE047\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE067\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE087\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE008\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE028\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE048\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE068\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE088\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE009\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE029\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE049\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE069\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE089\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE010\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE030\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE050\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE070\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE090\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE011\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE031\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE051\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE071\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE091\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE012\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE032\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE052\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE072\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE092\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE013\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE033\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE053\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE073\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE093\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE014\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE034\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE054\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE074\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE094\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE015\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE035\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE055\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE075\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE095\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE016\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE036\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE056\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE076\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE096\u001b[m\u001b[m/\n",
+      "\u001b[1m\u001b[36mDE017\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE037\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE057\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE077\u001b[m\u001b[m/         \u001b[31mcontents.json\u001b[m\u001b[m*\n",
+      "\u001b[1m\u001b[36mDE018\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE038\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE058\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE078\u001b[m\u001b[m/         \u001b[31mtruth.json\u001b[m\u001b[m*\n",
+      "\u001b[1m\u001b[36mDE019\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE039\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE059\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE079\u001b[m\u001b[m/         \u001b[31mtruth.txt\u001b[m\u001b[m*\n",
+      "\u001b[1m\u001b[36mDE020\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE040\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE060\u001b[m\u001b[m/         \u001b[1m\u001b[36mDE080\u001b[m\u001b[m/\n"
      ]
     }
    ],
@@ -91,6 +103,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -106,11 +119,13 @@
    "outputs": [],
    "source": [
     "from ruzicka.utilities import *\n",
-    "D = '../data/2014/du_essays/'\n",
-    "dev_train_data, dev_test_data = load_pan_dataset(D+'train')"
+    "\n",
+    "D = \"../data/2014/du_essays/\"\n",
+    "dev_train_data, dev_test_data = load_pan_dataset(D + \"train\")"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -130,6 +145,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -147,26 +163,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "+  ﻿Dankzij het internet zijn we een grote bron aan informatie rijker .\n",
-      "+  ﻿Het is dus begrijpelijk dat de commerciële zenders meer reclame mo\n",
-      "+  ﻿\" Hey , vuile nicht ! Hangt er nog stront aan je lul ? \" . Dergelij\n",
-      "+  ﻿Gelijkheid tussen man en vrouw is iets dat ons al eeuwen in de ban \n",
-      "+  ﻿Gisteren was er opnieuw een protest tegen homofilie in de grootstad\n",
-      "+  ﻿Voetbal is vandaag de dag zonder twijfel de populairste sport in Be\n",
-      "+  ﻿Door de ongekende groei van nieuwsbronnen en de opkomst van het int\n",
-      "+  ﻿Woordenboekgebruik uit interesse De categorie woordenboekgebruikers\n",
-      "+  ﻿Ze bouwden een tegencultuur op die alles verwierp waar hun ouders a\n",
-      "+  ﻿Als we hier in België op straat rondlopen , merken we dat er zeer \n"
+      "+  ﻿Dankzij het internet zijn we een grote bron aan informatie rijker . A\n",
+      "+  ﻿Het is dus begrijpelijk dat de commerciële zenders meer reclame moete\n",
+      "+  ﻿\" Hey , vuile nicht ! Hangt er nog stront aan je lul ? \" . Dergelijke\n",
+      "+  ﻿Gelijkheid tussen man en vrouw is iets dat ons al eeuwen in de ban ho\n",
+      "+  ﻿Gisteren was er opnieuw een protest tegen homofilie in de grootstad P\n",
+      "+  ﻿Voetbal is vandaag de dag zonder twijfel de populairste sport in Belg\n",
+      "+  ﻿Door de ongekende groei van nieuwsbronnen en de opkomst van het inter\n",
+      "+  ﻿Woordenboekgebruik uit interesse De categorie woordenboekgebruikers d\n",
+      "+  ﻿Ze bouwden een tegencultuur op die alles verwierp waar hun ouders alt\n",
+      "+  ﻿Als we hier in België op straat rondlopen , merken we dat er zeer vee\n"
      ]
     }
    ],
    "source": [
     "from __future__ import print_function\n",
+    "\n",
     "for doc in dev_test_documents[:10]:\n",
-    "    print('+ ', doc[:70])"
+    "    print(\"+ \", doc[:70])"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -199,10 +217,11 @@
    ],
    "source": [
     "for doc in dev_test_labels[:10]:\n",
-    "    print('+ ', doc[:70])"
+    "    print(\"+ \", doc[:70])"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -218,16 +237,15 @@
    "outputs": [],
    "source": [
     "from ruzicka.vectorization import Vectorizer\n",
-    "vectorizer = Vectorizer(mfi = 10000,\n",
-    "                        vector_space = 'tf',\n",
-    "                        ngram_type = 'word',\n",
-    "                        ngram_size = 1)\n",
+    "\n",
+    "vectorizer = Vectorizer(mfi=10000, vector_space=\"tf\", ngram_type=\"word\", ngram_size=1)\n",
     "\n",
     "dev_train_X = vectorizer.fit_transform(dev_train_documents).toarray()\n",
     "dev_test_X = vectorizer.transform(dev_test_documents).toarray()"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -256,6 +274,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -273,15 +292,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24\n",
-      " 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49\n",
-      " 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74\n",
-      " 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95]\n"
+      "[ 0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23\n",
+      " 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47\n",
+      " 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71\n",
+      " 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95]\n"
      ]
     }
    ],
    "source": [
     "from sklearn.preprocessing import LabelEncoder\n",
+    "\n",
     "label_encoder = LabelEncoder()\n",
     "label_encoder.fit(dev_train_labels + dev_test_labels)\n",
     "dev_train_y = label_encoder.transform(dev_train_labels)\n",
@@ -290,6 +310,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -305,14 +326,15 @@
    "outputs": [],
    "source": [
     "from ruzicka.Order2Verifier import Order2Verifier\n",
-    "dev_verifier = Order2Verifier(metric = 'minmax',\n",
-    "                              base = 'profile',\n",
-    "                              nb_bootstrap_iter=100,\n",
-    "                              rnd_prop = 0.5)\n",
+    "\n",
+    "dev_verifier = Order2Verifier(\n",
+    "    metric=\"minmax\", base=\"profile\", nb_bootstrap_iter=100, rnd_prop=0.5\n",
+    ")\n",
     "dev_verifier.fit(dev_train_X, dev_train_y)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -326,16 +348,6 @@
     "collapsed": false
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "ruzicka/Order2Verifier.py:191: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison\n",
-      "  if rnd_feature_idxs == 'all': # use entire feature space\n",
-      "ruzicka/Order2Verifier.py:252: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison\n",
-      "  if rnd_feature_idxs == 'all':\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -353,12 +365,13 @@
     }
    ],
    "source": [
-    "dev_test_scores = dev_verifier.predict_proba(test_X = dev_test_X,\n",
-    "                                             test_y = dev_test_y,\n",
-    "                                             nb_imposters = 30)"
+    "dev_test_scores = dev_verifier.predict_proba(\n",
+    "    test_X=dev_test_X, test_y=dev_test_y, nb_imposters=30\n",
+    ")"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -376,21 +389,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 0.69        0.61000001  0.          0.          0.08        0.07        0.\n",
-      "  1.          1.          0.75999999  0.49000001  0.31        0.94        0.94\n",
-      "  0.01        0.38999999  0.54000002  0.          0.03        0.36000001\n",
-      "  0.          0.          0.56        0.38999999  0.          0.81999999\n",
-      "  0.          0.52999997  0.04        0.          0.          0.01\n",
-      "  0.25999999  0.          0.02        0.18000001  0.          0.07        0.09\n",
-      "  0.          0.23        0.70999998  0.02        0.77999997  1.          0.\n",
-      "  0.38        0.01        0.          0.23999999  0.01        0.40000001\n",
-      "  0.03        0.38        0.72000003  0.          0.02        0.76999998\n",
-      "  0.02        0.83999997  0.98000002  0.64999998  0.97000003  0.50999999\n",
-      "  0.68000001  0.89999998  0.41999999  0.16        0.56        0.87\n",
-      "  0.34999999  0.01        0.02        0.50999999  0.07        0.12\n",
-      "  0.20999999  0.          0.99000001  0.          0.88        0.38        0.\n",
-      "  0.          1.          0.          1.          0.76999998  0.01        0.\n",
-      "  0.          0.63        0.          0.          0.46000001  0.56      ]\n"
+      "[0.73 0.55 0.02 0.   0.13 0.05 0.01 1.   0.96 0.78 0.5  0.27 0.95 0.89\n",
+      " 0.01 0.42 0.55 0.   0.02 0.38 0.   0.   0.59 0.31 0.02 0.8  0.01 0.54\n",
+      " 0.02 0.01 0.   0.   0.24 0.   0.   0.19 0.   0.05 0.09 0.   0.2  0.68\n",
+      " 0.04 0.81 1.   0.   0.43 0.03 0.   0.23 0.02 0.46 0.07 0.37 0.71 0.\n",
+      " 0.03 0.69 0.01 0.82 0.97 0.56 0.96 0.47 0.65 0.95 0.42 0.17 0.48 0.89\n",
+      " 0.4  0.01 0.02 0.57 0.09 0.14 0.26 0.   0.98 0.   0.89 0.39 0.   0.\n",
+      " 1.   0.   1.   0.71 0.   0.   0.   0.54 0.   0.01 0.51 0.63]\n"
      ]
     }
    ],
@@ -399,6 +404,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -422,12 +428,13 @@
    ],
    "source": [
     "dev_gt_scores = load_ground_truth(\n",
-    "                    filepath=os.sep.join((D, 'train', 'truth.txt')),\n",
-    "                    labels=dev_test_labels)\n",
+    "    filepath=os.sep.join((D, \"train\", \"truth.txt\")), labels=dev_test_labels\n",
+    ")\n",
     "print(dev_gt_scores)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -445,22 +452,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "p1 for optimal combo: 0.08\n",
-      "p2 for optimal combo: 0.35\n",
-      "AUC for optimal combo: 0.955729166667\n",
-      "c@1 for optimal combo: 0.943142361111\n"
+      "p1 for optimal combo: 0.15000000000000002\n",
+      "p2 for optimal combo: 0.4100000000000001\n",
+      "AUC for optimal combo: 0.9526909722222222\n",
+      "c@1 for optimal combo: 0.9375\n"
      ]
     }
    ],
    "source": [
     "from ruzicka.score_shifting import ScoreShifter\n",
+    "\n",
     "shifter = ScoreShifter()\n",
-    "shifter.fit(predicted_scores=dev_test_scores,\n",
-    "            ground_truth_scores=dev_gt_scores)\n",
+    "shifter.fit(predicted_scores=dev_test_scores, ground_truth_scores=dev_gt_scores)\n",
     "dev_test_scores = shifter.transform(dev_test_scores)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -478,7 +486,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0.79849999845027919, 0.7465000092983245, 0.0, 0.0, 0.0063999998569488539, 0.005600000023841859, 0.0, 1.0, 1.0, 0.8439999938011169, 0.66850000619888306, 0.5, 0.96099999845027928, 0.96099999845027928, 0.00079999998211860673, 0.60349999070167537, 0.70100001394748679, 0.0, 0.00239999994635582, 0.58400000929832463, 0.0, 0.0, 0.71400000154972076, 0.60349999070167537, 0.0, 0.88299999535083762, 0.0, 0.69449998140335079, 0.0031999999284744269, 0.0, 0.0, 0.00079999998211860673, 0.5, 0.0, 0.0015999999642372135, 0.5, 0.0, 0.005600000023841859, 0.5, 0.0, 0.5, 0.81149998605251317, 0.0015999999642372135, 0.85699998140335087, 1.0, 0.0, 0.59699999690055849, 0.00079999998211860673, 0.0, 0.5, 0.00079999998211860673, 0.61000000387430187, 0.00239999994635582, 0.59699999690055849, 0.81800001859664917, 0.0, 0.0015999999642372135, 0.85049998760223389, 0.0015999999642372135, 0.89599998295307159, 0.98700001239776602, 0.77249998450279234, 0.98050001859664904, 0.68149999380111692, 0.7920000046491622, 0.93499998450279231, 0.62299999147653584, 0.5, 0.71400000154972076, 0.91550000309944157, 0.5, 0.00079999998211860673, 0.0015999999642372135, 0.68149999380111692, 0.005600000023841859, 0.5, 0.5, 0.0, 0.99350000619888301, 0.0, 0.92199999690055834, 0.59699999690055849, 0.0, 0.0, 1.0, 0.0, 1.0, 0.85049998760223389, 0.00079999998211860673, 0.0, 0.0, 0.75949999690055847, 0.0, 0.0, 0.64900000542402259, 0.71400000154972076]\n"
+      "[0.8407000112533569, 0.7345000070333481, 0.002999999932944775, 0.0, 0.019499999284744267, 0.00750000011175871, 0.0014999999664723875, 1.0, 0.9763999873399734, 0.8701999831199645, 0.7050000000000001, 0.5, 0.9704999929666518, 0.9350999915599822, 0.0014999999664723875, 0.6577999922633171, 0.7345000070333481, 0.0, 0.002999999932944775, 0.5, 0.0, 0.0, 0.7580999845266343, 0.5, 0.002999999932944775, 0.882000007033348, 0.0014999999664723875, 0.7286000126600265, 0.002999999932944775, 0.0014999999664723875, 0.0, 0.0, 0.5, 0.0, 0.0, 0.5, 0.0, 0.00750000011175871, 0.013500000536441806, 0.0, 0.5, 0.8112000042200088, 0.00599999986588955, 0.8879000014066696, 1.0, 0.0, 0.6637000042200089, 0.0044999998994171625, 0.0, 0.5, 0.002999999932944775, 0.6814000049233437, 0.010500000044703485, 0.5, 0.8288999873399734, 0.0, 0.0044999998994171625, 0.8170999985933304, 0.0014999999664723875, 0.8937999957799911, 0.9823000168800353, 0.7404000014066696, 0.9763999873399734, 0.6872999992966652, 0.7934999859333038, 0.9704999929666518, 0.6577999922633171, 0.5, 0.6931999936699867, 0.9350999915599822, 0.5, 0.0014999999664723875, 0.002999999932944775, 0.7462999957799912, 0.013500000536441806, 0.02100000008940697, 0.5, 0.0, 0.9882000112533569, 0.0, 0.9350999915599822, 0.5, 0.0, 0.0, 1.0, 0.0, 1.0, 0.8288999873399734, 0.0, 0.0, 0.0, 0.7286000126600265, 0.0, 0.0014999999664723875, 0.7108999943733215, 0.7816999971866607]\n"
      ]
     }
    ],
@@ -487,6 +495,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -504,25 +513,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy:  0.885416666667\n",
-      "AUC:  0.955729166667\n",
-      "c@1:  0.943142361111\n",
-      "AUC x c@1:  0.901388662833\n"
+      "Accuracy:  0.8645833333333334\n",
+      "AUC:  0.9526909722222222\n",
+      "c@1:  0.9375\n",
+      "AUC x c@1:  0.8931477864583334\n"
      ]
     }
    ],
    "source": [
     "from ruzicka.evaluation import pan_metrics\n",
-    "dev_acc_score, dev_auc_score, dev_c_at_1_score = \\\n",
-    "    pan_metrics(prediction_scores=dev_test_scores,\n",
-    "    ground_truth_scores=dev_gt_scores)\n",
-    "print('Accuracy: ', dev_acc_score)\n",
-    "print('AUC: ', dev_auc_score)\n",
-    "print('c@1: ', dev_c_at_1_score)\n",
-    "print('AUC x c@1: ', dev_auc_score * dev_c_at_1_score)\n"
+    "\n",
+    "dev_acc_score, dev_auc_score, dev_c_at_1_score = pan_metrics(\n",
+    "    prediction_scores=dev_test_scores, ground_truth_scores=dev_gt_scores\n",
+    ")\n",
+    "print(\"Accuracy: \", dev_acc_score)\n",
+    "print(\"AUC: \", dev_auc_score)\n",
+    "print(\"c@1: \", dev_c_at_1_score)\n",
+    "print(\"AUC x c@1: \", dev_auc_score * dev_c_at_1_score)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -549,61 +560,56 @@
       "\t - # test documents processed: 70 out of 96\n",
       "\t - # test documents processed: 80 out of 96\n",
       "\t - # test documents processed: 90 out of 96\n",
-      "Accuracy:  0.864583333333\n",
-      "AUC:  0.9609375\n",
-      "c@1:  0.911458333333\n",
-      "AUC x c@1:  0.875854492187\n"
+      "Accuracy:  0.8541666666666666\n",
+      "AUC:  0.9605034722222222\n",
+      "c@1:  0.9071180555555555\n",
+      "AUC x c@1:  0.8712900420765817\n"
      ]
     }
    ],
    "source": [
-    "train_data, test_data = load_pan_dataset(D+'test')\n",
+    "train_data, test_data = load_pan_dataset(D + \"test\")\n",
     "train_labels, train_documents = zip(*train_data)\n",
     "test_labels, test_documents = zip(*test_data)\n",
-    "                \n",
+    "\n",
     "# vectorize:\n",
-    "vectorizer = Vectorizer(mfi = 10000,\n",
-    "                        vector_space = 'tf',\n",
-    "                        ngram_type = 'word',\n",
-    "                        ngram_size = 1)\n",
+    "vectorizer = Vectorizer(mfi=10000, vector_space=\"tf\", ngram_type=\"word\", ngram_size=1)\n",
     "train_X = vectorizer.fit_transform(train_documents).toarray()\n",
     "test_X = vectorizer.transform(test_documents).toarray()\n",
-    "                \n",
+    "\n",
     "# encode author labels:\n",
     "label_encoder = LabelEncoder()\n",
-    "label_encoder.fit(train_labels+test_labels)\n",
+    "label_encoder.fit(train_labels + test_labels)\n",
     "train_y = label_encoder.transform(train_labels)\n",
     "test_y = label_encoder.transform(test_labels)\n",
-    "                \n",
+    "\n",
     "# fit and predict a verifier on the test data:\n",
-    "test_verifier = Order2Verifier(metric = 'minmax',\n",
-    "                               base = 'profile',\n",
-    "                               nb_bootstrap_iter=100,\n",
-    "                               rnd_prop = 0.5)\n",
+    "test_verifier = Order2Verifier(\n",
+    "    metric=\"minmax\", base=\"profile\", nb_bootstrap_iter=100, rnd_prop=0.5\n",
+    ")\n",
     "test_verifier.fit(train_X, train_y)\n",
-    "test_scores = test_verifier.predict_proba(test_X=test_X,\n",
-    "                                          test_y=test_y,\n",
-    "                                          nb_imposters=30)\n",
-    "                \n",
+    "test_scores = test_verifier.predict_proba(test_X=test_X, test_y=test_y, nb_imposters=30)\n",
+    "\n",
     "# load the ground truth:\n",
     "test_gt_scores = load_ground_truth(\n",
-    "                    filepath=os.sep.join((D, 'test', 'truth.txt')),\n",
-    "                    labels=test_labels)\n",
-    "                \n",
+    "    filepath=os.sep.join((D, \"test\", \"truth.txt\")), labels=test_labels\n",
+    ")\n",
+    "\n",
     "# apply the optimzed score shifter:\n",
     "test_scores = shifter.transform(test_scores)\n",
-    "                \n",
-    "test_acc_score, test_auc_score, test_c_at_1_score = \\\n",
-    "    pan_metrics(prediction_scores=test_scores,\n",
-    "                ground_truth_scores=test_gt_scores)\n",
     "\n",
-    "print('Accuracy: ', test_acc_score)\n",
-    "print('AUC: ', test_auc_score)\n",
-    "print('c@1: ', test_c_at_1_score)\n",
-    "print('AUC x c@1: ', test_auc_score * test_c_at_1_score)"
+    "test_acc_score, test_auc_score, test_c_at_1_score = pan_metrics(\n",
+    "    prediction_scores=test_scores, ground_truth_scores=test_gt_scores\n",
+    ")\n",
+    "\n",
+    "print(\"Accuracy: \", test_acc_score)\n",
+    "print(\"AUC: \", test_auc_score)\n",
+    "print(\"c@1: \", test_c_at_1_score)\n",
+    "print(\"AUC x c@1: \", test_auc_score * test_c_at_1_score)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -611,6 +617,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -618,10 +625,58 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "It is interesting now to compare the GI approach to a first-order verification system, which often yields very competitive results too. Our implementation closely resembles the system proposed by Potha and Stamatatos in 2014 (A Profile-based Method for Authorship Verification). We import and fit this O1 verifier:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0.6975731  0.7034548  0.40138882 0.32841128 0.4868254  0.43319505\n",
+      " 0.38204736 0.8891614  0.8856941  0.65019494 0.58696884 0.5480333\n",
+      " 0.8099436  0.71765405 0.24394971 0.5510135  0.3095544  0.18303102\n",
+      " 0.41029483 0.5063761  0.39518255 0.20231014 0.56074613 0.43544942\n",
+      " 0.37015074 0.5194289  0.29052383 0.4464391  0.3594094  0.24937207\n",
+      " 0.31979412 0.29739827 0.36385065 0.2593767  0.29248828 0.4547326\n",
+      " 0.20648855 0.40505153 0.20148689 0.31327838 0.4837969  0.64704436\n",
+      " 0.34279436 0.6349254  0.9198616  0.1382832  0.4663418  0.3931684\n",
+      " 0.26801997 0.24117368 0.3338954  0.35352033 0.36349016 0.21679121\n",
+      " 0.62807065 0.18063825 0.44475883 0.70594865 0.39799708 0.6576137\n",
+      " 0.46410638 0.6396907  0.81281894 0.6116846  0.59626037 0.6942665\n",
+      " 0.55648714 0.38163322 0.6003838  0.7621097  0.11407489 0.\n",
+      " 0.0229103  0.47921854 0.21442336 0.06848055 0.32174557 0.288647\n",
+      " 0.8303501  0.3065713  0.45135087 0.4558156  0.29662842 0.26255327\n",
+      " 0.898336   0.26605827 1.         0.6276396  0.25173336 0.13219732\n",
+      " 0.31006557 0.4544739  0.3207541  0.18185502 0.51010543 0.5678939 ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ruzicka.Order1Verifier import Order1Verifier\n",
+    "\n",
+    "dev_verifier = Order1Verifier(metric=\"minmax\", base=\"profile\")\n",
+    "dev_verifier.fit(dev_train_X, dev_train_y)\n",
+    "dev_test_scores = dev_verifier.predict_proba(test_X=dev_test_X, test_y=dev_test_y)\n",
+    "print(dev_test_scores)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that in this case, the 'probabilities' returned are only distance-based pseudo-probabilities and don't lie in the range of 0-1. Applying the score shifter is therefore quintessential with O1, since it will scale the distances to a more useful range:"
    ]
   },
   {
@@ -635,70 +690,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 0.0508821   0.05295295 -0.05339944 -0.07909369 -0.02331865 -0.04220104\n",
-      " -0.06020927  0.11833715  0.11711633  0.03420103  0.01194018 -0.00176835\n",
-      "  0.09044588  0.05795223 -0.10883117 -0.00071907 -0.08573282 -0.13027966\n",
-      " -0.05026388 -0.01643515 -0.05558467 -0.12349176  0.0027076  -0.04140735\n",
-      " -0.06439781 -0.01183951 -0.09243321 -0.03753805 -0.06817973 -0.10692203\n",
-      " -0.08212757 -0.09001279 -0.06661606 -0.10339952 -0.09174156 -0.03461802\n",
-      " -0.1220206  -0.05210984 -0.12378168 -0.08442163 -0.02438498  0.03309178\n",
-      " -0.07402968  0.02882493  0.12914622 -0.14603448 -0.03053057 -0.05629373\n",
-      " -0.10035634 -0.10980856 -0.07716274 -0.07025313 -0.0667429  -0.11839318\n",
-      "  0.02641141 -0.13112211 -0.03812957  0.05383098 -0.05459356  0.03681302\n",
-      " -0.03131771  0.03050268  0.0914582   0.02064216  0.01521158  0.0497179\n",
-      "  0.00120807 -0.06035507  0.01666337  0.07360435 -0.15455794 -0.19472182\n",
-      " -0.18665552 -0.02599692 -0.11922693 -0.1706109  -0.08144045 -0.09309399\n",
-      "  0.09763068 -0.08678317 -0.03580868 -0.03423667 -0.09028387 -0.10228109\n",
-      "  0.12156731 -0.10104704  0.15736157  0.02625966 -0.10609066 -0.14817739\n",
-      " -0.08555293 -0.0347091  -0.08178961 -0.13069367 -0.01512218  0.00522423]\n"
-     ]
-    }
-   ],
-   "source": [
-    "from ruzicka.Order1Verifier import Order1Verifier\n",
-    "dev_verifier = Order1Verifier(metric = 'minmax',\n",
-    "                              base = 'profile')\n",
-    "dev_verifier.fit(dev_train_X, dev_train_y)\n",
-    "dev_test_scores = dev_verifier.predict_proba(test_X = dev_test_X,\n",
-    "                                             test_y = dev_test_y)\n",
-    "print(dev_test_scores)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that in this case, the 'probabilities' returned are only distance-based pseudo-probabilities and don't lie in the range of 0-1. Applying the score shifter is therefore quintessential with O1, since it will scale the distances to a more useful range:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 87,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "p1 for optimal combo: 0.4\n",
-      "p2 for optimal combo: 0.48\n",
-      "AUC for optimal combo: 0.900607638889\n",
-      "c@1 for optimal combo: 0.875217013889\n",
-      "[0.84273804257641682, 0.84579651967613234, 0.16055557333113935, 0.13136447581750335, 0.5, 0.5, 0.15281896211244364, 0.94236395287675823, 0.94056089246296626, 0.81810138143372435, 0.78522383099719839, 0.76497738691808459, 0.90117068640332054, 0.85318007055721723, 0.097579896593504079, 0.76652709278296061, 0.12382180468222422, 0.073212381489759837, 0.1641178680337276, 0.74331566101724755, 0.1580729506571803, 0.080924073032932753, 0.77158802155890516, 0.5, 0.14806038755174178, 0.75010306283465722, 0.11620952097510422, 0.5, 0.14376377501934579, 0.099748856395121779, 0.12791770548024634, 0.11895935299583767, 0.14554024993147938, 0.10375076667785683, 0.11699530335218733, 0.5, 0.082595451922209323, 0.16202068773225708, 0.080594699930370509, 0.1253114324598073, 0.5, 0.81646311591762899, 0.13711767047081092, 0.81016129564706429, 0.95832810646525068, 0.055313418246450516, 0.5, 0.15726739505930193, 0.10720810079060721, 0.096469481269528826, 0.13355821986162472, 0.14140818851734535, 0.1453961491991084, 0.086716543261792553, 0.80659672566975438, 0.072255276343457478, 0.5, 0.84709331114940478, 0.15919894077835728, 0.82195909618097507, 0.5, 0.8126392052519571, 0.90266581276148095, 0.79807598435680915, 0.79005543781347454, 0.84101861205194739, 0.76937332602672193, 0.1526533275300285, 0.79219962014423961, 0.87629704456372703, 0.045629957377535973, 0.0, 0.0091640752404909525, 0.5, 0.085769324725887816, 0.027392276153343366, 0.12869834140260192, 0.11545881574997982, 0.91178208691786444, 0.12262850435053184, 0.5, 0.5, 0.11865137831030044, 0.10502139926348139, 0.94713464192102259, 0.10642340187767725, 1.0, 0.80637259756637025, 0.1006933662706436, 0.05287887429428817, 0.12402617310811503, 0.5, 0.12830165808952429, 0.072742022614266974, 0.74525481807197902, 0.77530488596624436]\n"
+      "p1 for optimal combo: 0.42000000000000004\n",
+      "p2 for optimal combo: 0.49000000000000005\n",
+      "AUC for optimal combo: 0.9006076388888888\n",
+      "c@1 for optimal combo: 0.8752170138888888\n",
+      "[0.8457622939348222, 0.8487619441747666, 0.16858330607414246, 0.13793273806571962, 0.5, 0.5, 0.1604598891735077, 0.9434723180532456, 0.9417039841413499, 0.8215994209051133, 0.7893541079759598, 0.7694969815015793, 0.9030712443590165, 0.8560035651922226, 0.10245887875556947, 0.7710168999433518, 0.1300128471851349, 0.07687302947044374, 0.17232382893562317, 0.7482518047094346, 0.16597667098045352, 0.08497026085853578, 0.7759805279970169, 0.5, 0.1554633128643036, 0.7549087435007096, 0.12202000737190248, 0.5, 0.1509519445896149, 0.10473626732826234, 0.13431352972984315, 0.12490727305412294, 0.15281727433204653, 0.10893821597099305, 0.12284507632255555, 0.5, 0.08672519087791444, 0.17012164235115054, 0.08462449193000794, 0.1315769183635712, 0.5, 0.8199926239252091, 0.1439736306667328, 0.813811966776848, 0.9591294234991075, 0.05807894110679627, 0.5, 0.1651307237148285, 0.1125683891773224, 0.10129294753074647, 0.14023606181144715, 0.14847854018211365, 0.15266586899757387, 0.09105230927467348, 0.8103160327672959, 0.07586806654930116, 0.5, 0.8500338119268418, 0.16715877413749697, 0.8253829842805863, 0.5, 0.8162422555685044, 0.9045376616716385, 0.801959156394005, 0.7940927881002426, 0.8440759140253067, 0.7738084429502488, 0.16028595328330994, 0.7961957472562791, 0.8786759454011918, 0.04791145205497742, 0.0, 0.009622324705123902, 0.5, 0.09005781054496766, 0.028761831521987916, 0.1351331412792206, 0.12123173832893373, 0.9134785515069962, 0.12875994801521304, 0.5, 0.5, 0.12458393454551699, 0.11027237534523011, 0.9481513565778733, 0.11174447178840638, 1.0, 0.8100961917638779, 0.10572801232337953, 0.05552287459373475, 0.13022753834724426, 0.5, 0.13471672654151917, 0.07637910962104798, 0.750153769850731, 0.779625900387764]\n"
      ]
     }
    ],
    "source": [
     "shifter = ScoreShifter()\n",
-    "shifter.fit(predicted_scores=dev_test_scores,\n",
-    "            ground_truth_scores=dev_gt_scores)\n",
+    "shifter.fit(predicted_scores=dev_test_scores, ground_truth_scores=dev_gt_scores)\n",
     "dev_test_scores = shifter.transform(dev_test_scores)\n",
     "print(dev_test_scores)"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "collapsed": false
@@ -709,7 +717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {
     "collapsed": false
    },
@@ -718,91 +726,70 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy:  0.5\n",
-      "AUC:  0.881944444444\n",
-      "c@1:  0.637478298611\n",
-      "AUC x c@1:  0.562220443914\n"
+      "Accuracy:  0.8333333333333334\n",
+      "AUC:  0.8895399305555555\n",
+      "c@1:  0.8522135416666666\n",
+      "AUC x c@1:  0.7580779746726706\n"
      ]
     }
    ],
    "source": [
-    "train_data, test_data = load_pan_dataset(D+'test')\n",
+    "train_data, test_data = load_pan_dataset(D + \"test\")\n",
     "train_labels, train_documents = zip(*train_data)\n",
     "test_labels, test_documents = zip(*test_data)\n",
-    "                \n",
+    "\n",
     "# vectorize:\n",
-    "vectorizer = Vectorizer(mfi = 10000,\n",
-    "                        vector_space = 'tf',\n",
-    "                        ngram_type = 'word',\n",
-    "                        ngram_size = 1)\n",
+    "vectorizer = Vectorizer(mfi=10000, vector_space=\"tf\", ngram_type=\"word\", ngram_size=1)\n",
     "train_X = vectorizer.fit_transform(train_documents).toarray()\n",
     "test_X = vectorizer.transform(test_documents).toarray()\n",
-    "                \n",
+    "\n",
     "# encode author labels:\n",
     "label_encoder = LabelEncoder()\n",
-    "label_encoder.fit(train_labels+test_labels)\n",
+    "label_encoder.fit(train_labels + test_labels)\n",
     "train_y = label_encoder.transform(train_labels)\n",
     "test_y = label_encoder.transform(test_labels)\n",
-    "                \n",
+    "\n",
     "# fit and predict a verifier on the test data:\n",
-    "test_verifier = Order1Verifier(metric = 'minmax',\n",
-    "                               base = 'profile')\n",
+    "test_verifier = Order1Verifier(metric=\"minmax\", base=\"profile\")\n",
     "test_verifier.fit(train_X, train_y)\n",
-    "test_scores = test_verifier.predict_proba(test_X=test_X,\n",
-    "                                          test_y=test_y)\n",
-    "                \n",
+    "test_scores = test_verifier.predict_proba(test_X=test_X, test_y=test_y)\n",
+    "\n",
     "# load the ground truth:\n",
     "test_gt_scores = load_ground_truth(\n",
-    "                    filepath=os.sep.join((D, 'test', 'truth.txt')),\n",
-    "                    labels=test_labels)\n",
-    "                \n",
+    "    filepath=os.sep.join((D, \"test\", \"truth.txt\")), labels=test_labels\n",
+    ")\n",
+    "\n",
     "# apply the optimzed score shifter:\n",
     "test_scores = shifter.transform(test_scores)\n",
-    "                \n",
-    "test_acc_score, test_auc_score, test_c_at_1_score = \\\n",
-    "    pan_metrics(prediction_scores=test_scores,\n",
-    "                ground_truth_scores=test_gt_scores)\n",
     "\n",
-    "print('Accuracy: ', test_acc_score)\n",
-    "print('AUC: ', test_auc_score)\n",
-    "print('c@1: ', test_c_at_1_score)\n",
-    "print('AUC x c@1: ', test_auc_score * test_c_at_1_score)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Interestingly, O1 maintains a healthy AUC, but its accuracy and c@1 are disappointing. This is, by the way, certainly not true for other data sets: as we show in the paper, O1 produces relatively high scores in other corpora."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "collapsed": true
-   },
-   "source": [
-    "----------------------------"
+    "test_acc_score, test_auc_score, test_c_at_1_score = pan_metrics(\n",
+    "    prediction_scores=test_scores, ground_truth_scores=test_gt_scores\n",
+    ")\n",
+    "\n",
+    "print(\"Accuracy: \", test_acc_score)\n",
+    "print(\"AUC: \", test_auc_score)\n",
+    "print(\"c@1: \", test_c_at_1_score)\n",
+    "print(\"AUC x c@1: \", test_auc_score * test_c_at_1_score)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "py39",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.11"
   }
  },
  "nbformat": 4,

--- a/code/ruzicka/test_metrics.py
+++ b/code/ruzicka/test_metrics.py
@@ -12,12 +12,13 @@ package is available:
     http://docs.continuum.io/numbapro/index
 """
 
-from numbapro import autojit
+import numba
 
-TARGET = 'cpu'
+TARGET = "cpu"
 
-@autojit(target=TARGET)
-def minmax(x, y, rnd_feature_idxs):
+
+@numba.jit
+def minmax(x, y: list[float], rnd_feature_idxs: list[int] = []):
     """
     Calculates the pairwise "minmax" distance between
     two vectors, but limited to the `rnd_feature_idxs`
@@ -52,7 +53,6 @@ def minmax(x, y, rnd_feature_idxs):
     a, b = 0.0, 0.0
 
     for i in rnd_feature_idxs:
-
         a, b = x[i], y[i]
 
         if a >= b:
@@ -62,10 +62,13 @@ def minmax(x, y, rnd_feature_idxs):
             maxs += b
             mins += a
 
-    return 1.0 - (mins / (maxs + 1e-6)) # avoid zero division
+    return 1.0 - (mins / (maxs + 1e-6))  # avoid zero division
 
 
-@autojit(target=TARGET)
+# TODO: below here updated to @numba.jit without checking anything!
+
+
+@numba.jit
 def manhattan(x, y, rnd_feature_idxs):
     """
     Calculates the conventional pairwise Manhattan city
@@ -97,7 +100,7 @@ def manhattan(x, y, rnd_feature_idxs):
     diff, z = 0.0, 0.0
 
     for i in rnd_feature_idxs:
-        z = x[i]-y[i]
+        z = x[i] - y[i]
 
         if z < 0.0:
             z = -z
@@ -106,7 +109,8 @@ def manhattan(x, y, rnd_feature_idxs):
 
     return diff
 
-@autojit(target=TARGET)
+
+@numba.jit
 def euclidean(x, y, rnd_feature_idxs):
     """
     Calculates the conventional pairwise Euclidean
@@ -138,62 +142,54 @@ def euclidean(x, y, rnd_feature_idxs):
 
     for i in rnd_feature_idxs:
         z = x[i] - y[i]
-        diff += (z * z)
-    
+        diff += z * z
+
     return math.sqrt(diff)
 
-@autojit(target=TARGET)
+
+@numba.jit
 def common_ngrams2(x, y, rnd_feature_idxs):
     diff = 0.0
 
     for i in rnd_feature_idxs:
         z = 0.0
 
-        #if x[i] > 0.0 or y[i] > 0.0: # take union ngrams (slightly better)
-        #if x[i] > 0.0 or y[i] > 0.0: # take intersection ngrams
-        #if x[i] > 0.0: # take intersection ngrams
-        if y[i] > 0.0: # only target text (works best):
-
+        # if x[i] > 0.0 or y[i] > 0.0: # take union ngrams (slightly better)
+        # if x[i] > 0.0 or y[i] > 0.0: # take intersection ngrams
+        # if x[i] > 0.0: # take intersection ngrams
+        if y[i] > 0.0:  # only target text (works best):
             z = (x[i] + y[i]) / 2.0
             z = (x[i] - y[i]) / z
-        
-            diff += (z * z)
+
+            diff += z * z
 
     return diff
 
-@autojit(target=TARGET)
+
+@numba.jit
 def common_ngrams(x, y, rnd_feature_idxs):
     diff, z = 0.0, 0.0
 
     for i in rnd_feature_idxs:
-
-        #if x[i] > 0.0 or y[i] > 0.0: # take union ngrams (slightly better)
-        #if x[i] > 0.0 or y[i] > 0.0: # take intersection ngrams
-        #if x[i] > 0.0: # take intersection ngrams
-        if y[i] > 0.0: # only target text (works best):
-
+        # if x[i] > 0.0 or y[i] > 0.0: # take union ngrams (slightly better)
+        # if x[i] > 0.0 or y[i] > 0.0: # take intersection ngrams
+        # if x[i] > 0.0: # take intersection ngrams
+        if y[i] > 0.0:  # only target text (works best):
             z = (2.0 * (x[i] - y[i])) / (x[i] + y[i])
-        
-            diff += (z * z)
+
+            diff += z * z
 
     return diff
 
-@autojit(target=TARGET)
-def cosine(x, y, rnd_feature_idxs):
 
+@numba.jit
+def cosine(x, y, rnd_feature_idxs):
     numerator, denom_a, denom_b = 0.0, 0.0, 0.0
 
     for i in rnd_feature_idxs:
-
         numerator += x[i] * y[i]
 
         denom_a += x[i] * x[i]
         denom_b += y[i] * y[i]
 
     return 1.0 - (numerator / (math.sqrt(denom_a) * math.sqrt(denom_b)))
-
-
-
-
-
-

--- a/code/ruzicka/vectorization.py
+++ b/code/ruzicka/vectorization.py
@@ -12,11 +12,13 @@ from sklearn.pipeline import Pipeline
 from sklearn.feature_extraction.text import TfidfVectorizer, CountVectorizer
 from sklearn.preprocessing import StandardScaler, Normalizer
 
+
 def identity(y):
     """
     Simple identity function.
     """
     return y.split()
+
 
 class StdDevScaler(BaseEstimator):
     """
@@ -70,10 +72,10 @@ class StdDevScaler(BaseEstimator):
             The scaled input data in sparse format.
 
         """
-        if not sp.isspmatrix_csr(X): # convert to sparse format if needed:
+        if not sp.isspmatrix_csr(X):  # convert to sparse format if needed:
             X = sp.csr_matrix(X, dtype=np.float64)
         for i in range(X.shape[0]):
-            start, end = X.indptr[i], X.indptr[i+1]
+            start, end = X.indptr[i], X.indptr[i + 1]
             X.data[start:end] /= self.weights_[X.indices[start:end]]
         return X
 
@@ -95,13 +97,21 @@ class Vectorizer:
 
     """
 
-    def __init__(self, mfi=100, ngram_type='word',
-                 ngram_size=1, vocabulary=None,
-                 vector_space='tf', lowercase=True,
-                 min_df=0, max_df=1.0, ignore=[]):
+    def __init__(
+        self,
+        mfi=100,
+        ngram_type="word",
+        ngram_size=1,
+        vocabulary=None,
+        vector_space="tf",
+        lowercase=True,
+        min_df=0.0,
+        max_df=1.0,
+        ignore=[],
+    ):
         """
         Initialize the vectorizer by setting up a
-        vectorization pipeline via sklearn as 
+        vectorization pipeline via sklearn as
         `self.transformer`
 
         Parameters
@@ -150,47 +160,47 @@ class Vectorizer:
         - 'bin': binary model, only captures presence of features
         """
 
-        if vector_space not in ('tf', 'tf_scaled', 'tf_std', 'tf_idf', 'bin'):
-            raise ValueError('Unsupported vector space model: %s' %(vector_space))
+        if vector_space not in ("tf", "tf_scaled", "tf_std", "tf_idf", "bin"):
+            raise ValueError("Unsupported vector space model: %s" % (vector_space))
 
-        
-        self.params = {'max_features': mfi,
-                 'max_df': max_df,
-                 'min_df': min_df,
-                 'preprocessor': None,
-                 'ngram_range': (ngram_size, ngram_size),
-                 'lowercase': False,
-                 'decode_error': 'ignore',
-                 'stop_words': ignore,
-                }
+        self.params = {
+            "max_features": mfi,
+            "max_df": max_df,
+            "min_df": min_df,
+            "preprocessor": None,
+            "ngram_range": (ngram_size, ngram_size),
+            "lowercase": False,
+            "decode_error": "ignore",
+            "stop_words": ignore,
+        }
 
-        if ngram_type == 'word':
-            self.params['tokenizer'] = identity
-        elif ngram_type in ('char', 'char_wb'):
-            self.params['analyzer'] = ngram_type
+        if ngram_type == "word":
+            self.params["tokenizer"] = identity
+        elif ngram_type in ("char", "char_wb"):
+            self.params["analyzer"] = ngram_type
 
         n = Normalizer(norm="l2", copy=False)
 
-        if vector_space == 'tf':
-            self.params['use_idf'] = False
+        if vector_space == "tf":
+            self.params["use_idf"] = False
             v = TfidfVectorizer(**self.params)
-            self.transformer = Pipeline([('s1', v), ('s2', n)])
+            self.transformer = Pipeline([("s1", v), ("s2", n)])
 
-        elif vector_space == 'tf_std':
-            self.params['use_idf'] = False
+        elif vector_space == "tf_std":
+            self.params["use_idf"] = False
             v = TfidfVectorizer(**self.params)
             scaler = StdDevScaler()
-            self.transformer = Pipeline([('s1', v), ('s2', scaler), ('s3', n)])
+            self.transformer = Pipeline([("s1", v), ("s2", scaler), ("s3", n)])
 
-        elif vector_space == 'tf_idf':
-            self.params['use_idf'] = True
+        elif vector_space == "tf_idf":
+            self.params["use_idf"] = True
             v = TfidfVectorizer(**self.params)
-            self.transformer = Pipeline([('s1', v), ('s2', n)])
+            self.transformer = Pipeline([("s1", v), ("s2", n)])
 
-        elif vector_space == 'bin':
-            self.params['binary'] = True
+        elif vector_space == "bin":
+            self.params["binary"] = True
             v = CountVectorizer(**self.params)
-            self.transformer = Pipeline([('s1', v), ('s2', n)])
+            self.transformer = Pipeline([("s1", v), ("s2", n)])
 
     def fit(self, texts):
         """
@@ -204,14 +214,14 @@ class Vectorizer:
             Assumed untokenized input in the case of
             `ngram_type`='word', else expects
             continguous strings.
-        
+
         Returns
         ----------
         X: array-like, [n_texts, n_features]
             Vectorized texts in sparse format.
         """
         self.transformer.fit(texts)
-        self.feature_names = self.transformer.named_steps['s1'].get_feature_names()
+        self.feature_names = self.transformer.named_steps["s1"].get_feature_names_out()
         return self
 
     def transform(self, texts):
@@ -220,5 +230,3 @@ class Vectorizer:
     def fit_transform(self, texts):
         self.fit(texts)
         return self.transform(texts)
-
-


### PR DESCRIPTION
Most changes are minimal to make things work (new numba JIT convention, sklearn API deprecations, etc). There is a substantive change to predict_proba in Order1Verifier where I MinMax scale based on the range in the test data, not the train data - this avoids negative pseudo probabilities (and greatly improves c@1)

WARNING: This is NOT TESTED apart from 'Quickstart.ipynb runs now'